### PR TITLE
fix: lint and removing projects that contain less than 100 stars

### DIFF
--- a/website/data/open-source/maintainers.yml
+++ b/website/data/open-source/maintainers.yml
@@ -1,6 +1,6 @@
 ---
-Bahia: 
-- daltonmenezes
+Bahia:
+  - daltonmenezes
 
 Brasilia:
   - cezarsa

--- a/website/data/open-source/projects.yml
+++ b/website/data/open-source/projects.yml
@@ -48,17 +48,16 @@ Observability:
 
 Machine Learning:
   - nubank/fklearn
-  
+
 Observability:
   - badtuxx/giropops-monitoring
-  
+
 Frameworks:
   - expressots/expressots
 
 Libraries:
   - giggio/node-chromedriver
   - ErickSimoes/Ultrasonic
-
 
 GitHub Power-Ups:
   - iuricode/readme-template
@@ -74,7 +73,7 @@ Learning & Education:
   - gustavofreze/kotlin4noobs
   - OtacilioN/awesome-hacktoberfest
   - ReciHub/FunnyAlgorithms
-  
+
 Machine Learning:
   - nubank/fklearn
 

--- a/website/data/open-source/projects.yml
+++ b/website/data/open-source/projects.yml
@@ -1,7 +1,4 @@
 ---
-Accessibility:
-  - folhascadentes/mamao-app
-
 Business Software:
   - tsuru/tsuru
   - RocketChat/Rocket.Chat
@@ -36,7 +33,6 @@ Developer Productivity & Tools:
   - raphamorim/react-ape
   - avelino/awesome-go
   - ujizin/camposer
-  - undistro/cel-playground
   - backend-br/vagas
   - backend-br/desafios
   - daltonmenezes/aura-theme
@@ -89,7 +85,6 @@ UI/UX:
 Security & Privacy:
   - htrgouvea/nipe
   - undistro/zora
-  - undistro/marvin
   - halencarjunior/BugBuntu
 
 Azure DevOps Tools:


### PR DESCRIPTION
Essa PR corrige a identação dos mantenedores e projetos, parece que deu problema na action por causa disso

https://github.com/github/brasil/actions/runs/5646601283/job/15294866098

E remove repositórios que contém menos de 100 estrelas, pois também estava dando erro nas actions

```
folhascadentes/mamao-app
undistro/cel-playground
undistro/marvin
```