### PR TITLE
Update action workflows

### DIFF
--- a/.github/workflows/trigger-deploy-on-comment.yml
+++ b/.github/workflows/trigger-deploy-on-comment.yml
@@ -18,7 +18,7 @@ jobs:
               core.setFailed("User not authorized to deploy")
             }
       - name: Trigger build
-        uses: benc-uk/workflow-dispatch@v1
+        uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc #v1.2.4
         with:
           repo: ${{ secrets.GITHUBBRASIL_REPO_NWO }}
           workflow: Trigger build when public PR is merged

--- a/.github/workflows/trigger-deploy-on-comment.yml
+++ b/.github/workflows/trigger-deploy-on-comment.yml
@@ -2,6 +2,7 @@ name: Trigger deploy on comment
 on:
   issue_comment:
     types: [created]
+permissions: read-all
 jobs:
   if_merged:
     if: github.event.issue.pull_request && contains(github.event.comment.body, '/deploy')

--- a/.github/workflows/website-pr-validation.yml
+++ b/.github/workflows/website-pr-validation.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions: read-all
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -40,6 +41,10 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     needs: lint
+    permissions:
+      contents: read
+      pull-requests: write
+      actions: write
     steps:
       - name: Checkout fork
         uses: actions/checkout@v3

--- a/.github/workflows/website-pr-validation.yml
+++ b/.github/workflows/website-pr-validation.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Check format of yaml file
         id: yaml-lint
-        uses: ibiqlik/action-yamllint@v3
+        uses: ibiqlik/action-yamllint@2576378a8e339169678f9939646ee3ee325e845c #v3.1.1
         with:
           strict: true
           file_or_dir: website/**/*.yml
@@ -49,7 +49,7 @@ jobs:
           ref: main
           repository: ${{ secrets.BRAZIL_REPO_NWO }}
           path: ./brazil-main
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4 #v1.207.0
         with:
           ruby-version: 3.0.0
       - name: Validate PR


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflows to enhance security and ensure the use of specific versions of actions. The most important changes include adding permissions to jobs and updating action versions.

### Permissions updates:

* [`.github/workflows/trigger-deploy-on-comment.yml`](diffhunk://#diff-9739ddf6436cb70d22efa2f9147dff2d1d746bfb907eb588cb80f7cbef329ff3R5): Added `permissions: read-all` to the workflow to ensure the necessary read permissions are granted.
* [`.github/workflows/website-pr-validation.yml`](diffhunk://#diff-a0ec11f3b718e2c2e3a992abf3502782d8c24cd0b4da8076e2fed0dbf7cc51c1R12-R18): Added `permissions: read-all` to the `lint` job and specific permissions to the `validate` job (`contents: read`, `pull-requests: write`, `actions: write`). [[1]](diffhunk://#diff-a0ec11f3b718e2c2e3a992abf3502782d8c24cd0b4da8076e2fed0dbf7cc51c1R12-R18) [[2]](diffhunk://#diff-a0ec11f3b718e2c2e3a992abf3502782d8c24cd0b4da8076e2fed0dbf7cc51c1R44-R47)

### Action version updates:

* [`.github/workflows/trigger-deploy-on-comment.yml`](diffhunk://#diff-9739ddf6436cb70d22efa2f9147dff2d1d746bfb907eb588cb80f7cbef329ff3L21-R22): Updated the `benc-uk/workflow-dispatch` action to use a specific commit hash for version `v1.2.4`.
* [`.github/workflows/website-pr-validation.yml`](diffhunk://#diff-a0ec11f3b718e2c2e3a992abf3502782d8c24cd0b4da8076e2fed0dbf7cc51c1R12-R18): Updated the `ibiqlik/action-yamllint` action to use a specific commit hash for version `v3.1.1`.
* [`.github/workflows/website-pr-validation.yml`](diffhunk://#diff-a0ec11f3b718e2c2e3a992abf3502782d8c24cd0b4da8076e2fed0dbf7cc51c1L52-R57): Updated the `ruby/setup-ruby` action to use a specific commit hash for version `v1.207.0`.